### PR TITLE
Surjection trait

### DIFF
--- a/src/dimensions/binary.rs
+++ b/src/dimensions/binary.rs
@@ -32,10 +32,6 @@ impl BoundedDimension for Binary {
     fn ub(&self) -> &bool { &true }
 
     fn contains(&self, _: Self::Value) -> bool { true }
-
-    fn is_infinite(&self) -> bool {
-        false
-    }
 }
 
 impl FiniteDimension for Binary {
@@ -44,23 +40,74 @@ impl FiniteDimension for Binary {
     }
 }
 
+impl Surjection<bool, bool> for Binary {
+    fn map(&self, val: bool) -> bool { val }
+}
+
 impl Surjection<f64, bool> for Binary {
-    fn map(&self, val: f64) -> Self::Value {
-        val >= 0.0
-    }
+    fn map(&self, val: f64) -> bool { val > 0.0 }
 }
 
 
 #[cfg(test)]
 mod tests {
+    use rand::thread_rng;
     use serde_test::{assert_tokens, Token};
     use super::*;
 
     #[test]
-    fn test_binary() {
+    fn test_span() {
         let d = Binary::new();
 
         assert_eq!(d.span(), Span::Finite(2));
+    }
+
+    #[test]
+    fn test_sampling() {
+        let d = Binary::new();
+        let mut rng = thread_rng();
+
+        for _ in 0..100 {
+            let s = d.sample(&mut rng);
+
+            assert!(s == false || s == true);
+            assert!(d.contains(s));
+        }
+    }
+
+    #[test]
+    fn test_bounds() {
+        let d = Binary::new();
+
+        assert_eq!(d.lb(), &false);
+        assert_eq!(d.ub(), &true);
+
+        assert!(d.contains(false));
+        assert!(d.contains(true));
+    }
+
+    #[test]
+    fn test_range() {
+        let d = Binary::new();
+        let r = d.range();
+
+        assert!(r == (false..true) || r == (true..false));
+    }
+
+    #[test]
+    fn test_surjection() {
+        let d = Binary::new();
+
+        assert_eq!(d.map(true), true);
+        assert_eq!(d.map(false), false);
+
+        assert_eq!(d.map(1.0), true);
+        assert_eq!(d.map(0.0), false);
+    }
+
+    #[test]
+    fn test_serialisation() {
+        let d = Binary::new();
 
         assert_tokens(&d, &[Token::UnitStruct { name: "Binary" }]);
     }

--- a/src/dimensions/binary.rs
+++ b/src/dimensions/binary.rs
@@ -1,3 +1,4 @@
+use Surjection;
 use rand::Rng;
 use super::*;
 
@@ -13,10 +14,6 @@ impl Binary {
 
 impl Dimension for Binary {
     type Value = bool;
-
-    fn convert(&self, val: f64) -> Self::Value {
-        val >= 0.0
-    }
 
     fn span(&self) -> Span {
         Span::Finite(2)
@@ -44,6 +41,12 @@ impl BoundedDimension for Binary {
 impl FiniteDimension for Binary {
     fn range(&self) -> Range<Self::Value> {
         false..true
+    }
+}
+
+impl Surjection<f64, bool> for Binary {
+    fn map(&self, val: f64) -> Self::Value {
+        val >= 0.0
     }
 }
 

--- a/src/dimensions/continuous.rs
+++ b/src/dimensions/continuous.rs
@@ -1,3 +1,4 @@
+use Surjection;
 use rand::distributions::{Range as RngRange, IndependentSample};
 use serde::{Deserialize, Deserializer, de};
 use serde::de::Visitor;
@@ -27,10 +28,6 @@ impl Continuous {
 impl Dimension for Continuous {
     type Value = f64;
 
-    fn convert(&self, val: f64) -> Self::Value {
-        clip!(self.lb, val, self.ub)
-    }
-
     fn span(&self) -> Span {
         Span::Infinite
     }
@@ -57,6 +54,12 @@ impl BoundedDimension for Continuous {
 
     fn is_infinite(&self) -> bool {
         self.lb.is_infinite() || self.ub.is_infinite()
+    }
+}
+
+impl Surjection<f64, f64> for Continuous {
+    fn map(&self, val: f64) -> f64 {
+        clip!(self.lb, val, self.ub)
     }
 }
 

--- a/src/dimensions/discrete.rs
+++ b/src/dimensions/discrete.rs
@@ -53,10 +53,6 @@ impl BoundedDimension for Discrete {
     fn contains(&self, val: Self::Value) -> bool {
         val < self.size
     }
-
-    fn is_infinite(&self) -> bool {
-        false
-    }
 }
 
 impl FiniteDimension for Discrete {
@@ -172,22 +168,55 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_discrete() {
+    fn test_span() {
+        for size in vec![5, 10, 100] {
+            let d = Discrete::new(size);
+
+            assert_eq!(d.span(), Span::Finite(size));
+        }
+    }
+
+    #[test]
+    fn test_sampling() {
         for size in vec![5, 10, 100] {
             let d = Discrete::new(size);
             let mut rng = thread_rng();
 
-            assert_eq!(d.span(), Span::Finite(size));
+            for _ in 0..100 {
+                let s = d.sample(&mut rng);
 
-            assert!(!d.contains(size));
+                assert!(s < size);
+            }
+        }
+    }
+
+    #[test]
+    fn test_bounds() {
+        for size in vec![5, 10, 100] {
+            let d = Discrete::new(size);
+
+            assert_eq!(d.lb(), &0);
+            assert_eq!(d.ub(), &(size - 1));
 
             assert!(d.contains(0));
             assert!(d.contains((size - 1)));
+            assert!(!d.contains(size));
+        }
+    }
 
-            for _ in 0..100 {
-                let s = d.sample(&mut rng);
-                assert!(s < size);
-            }
+    #[test]
+    fn test_surjection() {
+        let d = Discrete::new(10);
+
+        for i in 0..10 {
+            assert_eq!(d.map(i), i);
+        }
+    }
+
+    #[test]
+    fn test_serialisation() {
+        for size in vec![5, 10, 100] {
+            let d = Discrete::new(size);
 
             assert_tokens(&d,
                           &[Token::Struct {

--- a/src/dimensions/discrete.rs
+++ b/src/dimensions/discrete.rs
@@ -1,3 +1,4 @@
+use Surjection;
 use rand::distributions::{Range as RngRange, IndependentSample};
 use serde::{Deserialize, Deserializer, de};
 use serde::de::Visitor;
@@ -28,10 +29,6 @@ impl Discrete {
 
 impl Dimension for Discrete {
     type Value = usize;
-
-    fn convert(&self, val: f64) -> Self::Value {
-        val as usize
-    }
 
     fn sample(&self, rng: &mut ThreadRng) -> usize {
         self.range.ind_sample(rng)
@@ -65,6 +62,12 @@ impl BoundedDimension for Discrete {
 impl FiniteDimension for Discrete {
     fn range(&self) -> Range<Self::Value> {
         0..self.size
+    }
+}
+
+impl Surjection<usize, usize> for Discrete {
+    fn map(&self, val: usize) -> usize {
+        val as usize
     }
 }
 

--- a/src/dimensions/infinite.rs
+++ b/src/dimensions/infinite.rs
@@ -1,3 +1,4 @@
+use Surjection;
 use super::*;
 
 /// An infinite dimension.
@@ -13,16 +14,18 @@ impl Infinite {
 impl Dimension for Infinite {
     type Value = f64;
 
-    fn convert(&self, val: f64) -> Self::Value {
-        val
-    }
-
     fn span(&self) -> Span {
         Span::Infinite
     }
 
     fn sample(&self, _: &mut ThreadRng) -> f64 {
         unimplemented!()
+    }
+}
+
+impl Surjection<f64, f64> for Infinite {
+    fn map(&self, val: f64) -> f64 {
+        val
     }
 }
 

--- a/src/dimensions/infinite.rs
+++ b/src/dimensions/infinite.rs
@@ -29,25 +29,15 @@ impl Surjection<f64, f64> for Infinite {
     }
 }
 
-impl<D: BoundedDimension> From<D> for Infinite where D::Value: PartialOrd {
-    fn from(d: D) -> Infinite {
-        if d.is_infinite() {
-            Infinite
-        } else {
-            panic!("Upper or lower bound must be infinite for a valid conversion.")
-        }
-    }
-}
-
 
 #[cfg(test)]
 mod tests {
-    use rand::thread_rng;
+    use rand::{thread_rng, Rng};
     use serde_test::{assert_tokens, Token};
     use super::*;
 
     #[test]
-    fn test_infinite() {
+    fn test_span() {
         let d = Infinite;
 
         assert_eq!(d.span(), Span::Infinite);
@@ -57,10 +47,29 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_infinite_sample() {
+    fn test_sampling() {
         let d = Infinite;
         let mut rng = thread_rng();
 
         let _ = d.sample(&mut rng);
+    }
+
+    #[test]
+    fn test_surjection() {
+        let d = Infinite;
+        let mut rng = thread_rng();
+
+        for _ in 0..10 {
+            let v = rng.next_f64();
+
+            assert_eq!(d.map(v), v);
+        }
+    }
+
+    #[test]
+    fn test_serialisation() {
+        let d = Infinite;
+
+        assert_tokens(&d, &[Token::UnitStruct { name: "Infinite" }]);
     }
 }

--- a/src/dimensions/mod.rs
+++ b/src/dimensions/mod.rs
@@ -36,9 +36,6 @@ pub trait BoundedDimension: Dimension where Self::Value: PartialOrd {
 
     /// Returns true iff `val` is within the dimension's bounds.
     fn contains(&self, val: Self::ValueBound) -> bool;
-
-    /// Returns true if either the upper or lower bound are infinite.
-    fn is_infinite(&self) -> bool;
 }
 
 /// Dimension type with bounds and a finite set of values.

--- a/src/dimensions/mod.rs
+++ b/src/dimensions/mod.rs
@@ -11,9 +11,6 @@ pub trait Dimension {
     /// The corresponding primitive type.
     type Value: Debug + Clone;
 
-    /// Map a compatible input into a valid value of this dimension.
-    fn convert(&self, val: f64) -> Self::Value;
-
     /// Returns the total span of this dimension.
     fn span(&self) -> Span;
 
@@ -54,10 +51,6 @@ pub trait FiniteDimension: BoundedDimension where Self::Value: PartialOrd {
 impl<D: Dimension> Dimension for Box<D> {
     type Value = D::Value;
 
-    fn convert(&self, val: f64) -> Self::Value {
-        (**self).convert(val)
-    }
-
     fn span(&self) -> Span {
         (**self).span()
     }
@@ -69,10 +62,6 @@ impl<D: Dimension> Dimension for Box<D> {
 
 impl<'a, D: Dimension> Dimension for &'a D {
     type Value = D::Value;
-
-    fn convert(&self, val: f64) -> Self::Value {
-        (**self).convert(val)
-    }
 
     fn span(&self) -> Span {
         (**self).span()

--- a/src/dimensions/null.rs
+++ b/src/dimensions/null.rs
@@ -1,3 +1,4 @@
+use Surjection;
 use super::*;
 
 /// A null dimension.
@@ -7,10 +8,6 @@ pub struct Null;
 impl Dimension for Null {
     type Value = ();
 
-    fn convert(&self, _: f64) -> Self::Value {
-        ()
-    }
-
     fn span(&self) -> Span {
         Span::Null
     }
@@ -18,6 +15,10 @@ impl Dimension for Null {
     fn sample(&self, _: &mut ThreadRng) -> () {
         ()
     }
+}
+
+impl<T> Surjection<T, ()> for Null {
+    fn map(&self, _: T) -> () { () }
 }
 
 

--- a/src/dimensions/null.rs
+++ b/src/dimensions/null.rs
@@ -24,14 +24,41 @@ impl<T> Surjection<T, ()> for Null {
 
 #[cfg(test)]
 mod tests {
+    use rand::{thread_rng, Rng};
     use serde_test::{assert_tokens, Token};
     use super::*;
 
     #[test]
-    fn test_null() {
+    fn test_span() {
         let d = Null;
 
         assert_eq!(d.span(), Span::Null);
+    }
+
+    #[test]
+    fn test_sampling() {
+        let d = Null;
+        let mut rng = thread_rng();
+
+        for _ in 0..10 {
+            assert_eq!(d.sample(&mut rng), ());
+        }
+    }
+
+    #[test]
+    fn test_surjection() {
+        let d = Null;
+        let mut rng = thread_rng();
+
+        for _ in 0..10 {
+            assert_eq!(d.map(rng.next_f64()), ());
+            assert_eq!(d.map(rng.next_u64()), ());
+        }
+    }
+
+    #[test]
+    fn test_serialisation() {
+        let d = Null;
 
         assert_tokens(&d, &[Token::UnitStruct { name: "Null" }]);
     }

--- a/src/dimensions/partitioned.rs
+++ b/src/dimensions/partitioned.rs
@@ -91,10 +91,6 @@ impl BoundedDimension for Partitioned {
     fn contains(&self, val: Self::ValueBound) -> bool {
         (val >= self.lb) && (val < self.ub)
     }
-
-    fn is_infinite(&self) -> bool {
-        self.lb.is_infinite() || self.ub.is_infinite()
-    }
 }
 
 impl FiniteDimension for Partitioned {
@@ -105,6 +101,10 @@ impl FiniteDimension for Partitioned {
 
 impl Surjection<f64, usize> for Partitioned {
     fn map(&self, val: f64) -> usize { self.to_partition(val) }
+}
+
+impl Surjection<usize, usize> for Partitioned {
+    fn map(&self, val: usize) -> usize { clip!(0, val, self.density-1) }
 }
 
 impl<'de> Deserialize<'de> for Partitioned {
@@ -238,21 +238,69 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_partitioned() {
+    fn test_span() {
+        for (lb, ub, density) in vec![(0.0, 5.0, 5), (-5.0, 5.0, 10), (-5.0, 0.0, 5)] {
+            let d = Partitioned::new(lb, ub, density);
+
+            assert_eq!(d.span(), Span::Finite(density));
+        }
+    }
+
+    #[test]
+    fn test_sampling() {
         for (lb, ub, density) in vec![(0.0, 5.0, 5), (-5.0, 5.0, 10), (-5.0, 0.0, 5)] {
             let d = Partitioned::new(lb, ub, density);
             let mut rng = thread_rng();
 
-            assert_eq!(d.span(), Span::Finite(density));
+            for _ in 0..100 {
+                let s = d.sample(&mut rng);
+
+                assert!(s < density);
+            }
+        }
+    }
+
+    #[test]
+    fn test_bounds() {
+        for (lb, ub, density) in vec![(0.0, 5.0, 5), (-5.0, 5.0, 10), (-5.0, 0.0, 5)] {
+            let d = Partitioned::new(lb, ub, density);
+
+            assert_eq!(d.lb(), &lb);
+            assert_eq!(d.ub(), &ub);
 
             assert!(!d.contains(ub));
             assert!(d.contains(lb));
             assert!(d.contains(((lb + ub) / 2.0)));
+        }
+    }
 
-            for _ in 0..100 {
-                let s = d.sample(&mut rng);
-                assert!(s < density);
-            }
+    #[test]
+    fn test_surjection_f64() {
+        let d = Partitioned::new(0.0, 5.0, 6);
+
+        assert_eq!(d.map(-1.0), 0);
+        assert_eq!(d.map(0.0), 0);
+        assert_eq!(d.map(1.0), 1);
+        assert_eq!(d.map(2.0), 2);
+        assert_eq!(d.map(3.0), 3);
+        assert_eq!(d.map(4.0), 4);
+        assert_eq!(d.map(5.0), 5);
+        assert_eq!(d.map(6.0), 5);
+    }
+
+    #[test]
+    fn test_surjection_usize() {
+        let d = Partitioned::new(5.0, 6.0, 2);
+
+        assert_eq!(d.map(0), 0);
+        assert_eq!(d.map(1), 1);
+        assert_eq!(d.map(2), 1);
+    }
+
+    #[test]
+    fn test_serialisation() {
+        for (lb, ub, density) in vec![(0.0, 5.0, 5), (-5.0, 5.0, 10), (-5.0, 0.0, 5)] {
+            let d = Partitioned::new(lb, ub, density);
 
             assert_tokens(&d,
                           &[Token::Struct {

--- a/src/dimensions/partitioned.rs
+++ b/src/dimensions/partitioned.rs
@@ -1,3 +1,4 @@
+use Surjection;
 use rand::distributions::{Range as RngRange, IndependentSample};
 use serde::{Deserialize, Deserializer, de};
 use serde::de::Visitor;
@@ -67,10 +68,6 @@ impl Partitioned {
 impl Dimension for Partitioned {
     type Value = usize;
 
-    fn convert(&self, val: f64) -> Self::Value {
-        self.to_partition(val)
-    }
-
     fn span(&self) -> Span {
         Span::Finite(self.density)
     }
@@ -104,6 +101,10 @@ impl FiniteDimension for Partitioned {
     fn range(&self) -> Range<Self::Value> {
         0..(self.density + 1)
     }
+}
+
+impl Surjection<f64, usize> for Partitioned {
+    fn map(&self, val: f64) -> usize { self.to_partition(val) }
 }
 
 impl<'de> Deserialize<'de> for Partitioned {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,8 @@ pub type Vector<T = f64> = ndarray::Array1<T>;
 pub type Matrix<T = f64> = ndarray::Array2<T>;
 
 
+/// A trait for types implementing a mapping from values of one set onto another.
+pub trait Surjection<X, Y> {
+    /// Map value from domain onto codomain.
+    fn map(&self, from: X) -> Y;
+}

--- a/src/spaces/empty.rs
+++ b/src/spaces/empty.rs
@@ -8,16 +8,16 @@ pub struct EmptySpace;
 impl Space for EmptySpace {
     type Repr = ();
 
-    fn sample(&self, _: &mut ThreadRng) -> Self::Repr {
-        ()
-    }
-
     fn dim(&self) -> usize {
         0
     }
 
     fn span(&self) -> Span {
         Span::Null
+    }
+
+    fn sample(&self, _: &mut ThreadRng) -> Self::Repr {
+        ()
     }
 }
 
@@ -28,16 +28,31 @@ impl<T> Surjection<T, ()> for EmptySpace {
 
 #[cfg(test)]
 mod tests {
+    use {Space, Span, Surjection, EmptySpace};
     use rand::thread_rng;
-    use spaces::{Space, EmptySpace, Span};
 
     #[test]
-    fn test_empty_space() {
-        let ns = EmptySpace;
+    fn test_dim() {
+        assert_eq!(EmptySpace.dim(), 0);
+    }
+
+    #[test]
+    fn test_span() {
+        assert_eq!(EmptySpace.span(), Span::Null);
+    }
+
+    #[test]
+    fn test_sample() {
         let mut rng = thread_rng();
 
-        assert_eq!(ns.sample(&mut rng), ());
-        assert_eq!(ns.dim(), 0);
-        assert_eq!(ns.span(), Span::Null);
+        assert_eq!(EmptySpace.sample(&mut rng), ());
+    }
+
+    #[test]
+    fn test_surjection() {
+        assert_eq!(EmptySpace.map(1), ());
+        assert_eq!(EmptySpace.map(1.0), ());
+        assert_eq!(EmptySpace.map("test"), ());
+        assert_eq!(EmptySpace.map(Some(true)), ());
     }
 }

--- a/src/spaces/empty.rs
+++ b/src/spaces/empty.rs
@@ -1,4 +1,5 @@
-use super::*;
+use {Space, Span, Surjection};
+use rand::ThreadRng;
 
 /// An empty space.
 #[derive(Clone, Copy, Serialize, Deserialize, Debug)]
@@ -18,6 +19,10 @@ impl Space for EmptySpace {
     fn span(&self) -> Span {
         Span::Null
     }
+}
+
+impl<T> Surjection<T, ()> for EmptySpace {
+    fn map(&self, _: T) -> () { () }
 }
 
 

--- a/src/spaces/mod.rs
+++ b/src/spaces/mod.rs
@@ -2,11 +2,6 @@ use Span;
 use dimensions::{self, Dimension, Partitioned};
 use rand::ThreadRng;
 use std::fmt::Debug;
-use std::ops::{Add, Index};
-use std::iter::FromIterator;
-use std::slice::Iter as SliceIter;
-use std::collections::HashMap;
-use std::collections::hash_map::Iter as HashMapIter;
 
 
 /// Trait for defining geometric spaces.
@@ -14,14 +9,14 @@ pub trait Space {
     /// The data representation of the space.
     type Repr: Debug + Clone;
 
-    /// Generate a random sample from the space.
-    fn sample(&self, rng: &mut ThreadRng) -> Self::Repr;
-
     /// Return the number of dimensions in the space.
     fn dim(&self) -> usize;
 
     /// Return the number of linear combinations of values in the space.
     fn span(&self) -> Span;
+
+    /// Generate a random sample from the space.
+    fn sample(&self, rng: &mut ThreadRng) -> Self::Repr;
 }
 
 

--- a/src/spaces/named.rs
+++ b/src/spaces/named.rs
@@ -63,16 +63,16 @@ impl NamedSpace<Partitioned> {
 impl<D: Dimension> Space for NamedSpace<D> {
     type Repr = Vec<D::Value>;
 
-    fn sample(&self, rng: &mut ThreadRng) -> Self::Repr {
-        self.dimensions.values().map(|d| d.sample(rng)).collect()
-    }
-
     fn dim(&self) -> usize {
         self.dimensions.len()
     }
 
     fn span(&self) -> Span {
         self.span
+    }
+
+    fn sample(&self, rng: &mut ThreadRng) -> Self::Repr {
+        self.dimensions.values().map(|d| d.sample(rng)).collect()
     }
 }
 

--- a/src/spaces/named.rs
+++ b/src/spaces/named.rs
@@ -1,4 +1,10 @@
-use super::*;
+use {Dimension, Space, Span, Surjection};
+use dimensions::{Continuous, Partitioned};
+use rand::ThreadRng;
+use std::collections::HashMap;
+use std::collections::hash_map::Iter as HashMapIter;
+use std::iter::FromIterator;
+use std::ops::Add;
 
 /// Named, N-dimensional homogeneous space.
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -37,7 +43,7 @@ impl<D: Dimension> NamedSpace<D> {
     }
 }
 
-impl NamedSpace<dimensions::Continuous> {
+impl NamedSpace<Continuous> {
     pub fn partitioned(self, density: usize) -> NamedSpace<Partitioned> {
         self.into_iter()
             .map(|(name, d)| (name, Partitioned::from_continuous(d, density)))
@@ -45,7 +51,7 @@ impl NamedSpace<dimensions::Continuous> {
     }
 }
 
-impl NamedSpace<dimensions::Partitioned> {
+impl NamedSpace<Partitioned> {
     pub fn centres(&self) -> Vec<Vec<f64>> {
         self.dimensions
             .values()
@@ -58,7 +64,7 @@ impl<D: Dimension> Space for NamedSpace<D> {
     type Repr = Vec<D::Value>;
 
     fn sample(&self, rng: &mut ThreadRng) -> Self::Repr {
-        self.dimensions.iter().map(|(_, d)| d.sample(rng)).collect()
+        self.dimensions.values().map(|d| d.sample(rng)).collect()
     }
 
     fn dim(&self) -> usize {
@@ -67,6 +73,15 @@ impl<D: Dimension> Space for NamedSpace<D> {
 
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<D, X> Surjection<Vec<X>, Vec<D::Value>> for NamedSpace<D>
+where
+    D: Dimension + Surjection<X, <D as Dimension>::Value>,
+{
+    fn map(&self, val: Vec<X>) -> Vec<D::Value> {
+        self.dimensions.values().zip(val.into_iter()).map(|(d, v)| d.map(v)).collect()
     }
 }
 

--- a/src/spaces/pair.rs
+++ b/src/spaces/pair.rs
@@ -1,4 +1,6 @@
-use super::*;
+use {Dimension, Space, Span, Surjection};
+use dimensions::{Continuous, Partitioned};
+use rand::ThreadRng;
 
 /// 2-dimensional homogeneous space.
 #[derive(Clone, Copy, Serialize, Deserialize, Debug)]
@@ -12,7 +14,7 @@ impl<D1: Dimension, D2: Dimension> PairSpace<D1, D2> {
     }
 }
 
-impl PairSpace<dimensions::Continuous, dimensions::Continuous> {
+impl PairSpace<Continuous, Continuous> {
     pub fn partitioned(self, density: usize) -> PairSpace<Partitioned, Partitioned> {
         PairSpace((Partitioned::from_continuous((self.0).0, density),
                    Partitioned::from_continuous((self.0).1, density)))
@@ -32,6 +34,17 @@ impl<D1: Dimension, D2: Dimension> Space for PairSpace<D1, D2> {
 
     fn span(&self) -> Span {
         (self.0).0.span()*(self.0).1.span()
+    }
+}
+
+impl<D1, X1, D2, X2> Surjection<(X1, X2), (D1::Value, D2::Value)> for PairSpace<D1, D2>
+where
+    D1: Dimension + Surjection<X1, <D1 as Dimension>::Value>,
+    D2: Dimension + Surjection<X2, <D2 as Dimension>::Value>,
+{
+    fn map(&self, val: (X1, X2)) -> (D1::Value, D2::Value) {
+        ((self.0).0.map(val.0),
+         (self.0).1.map(val.1))
     }
 }
 

--- a/src/spaces/regular.rs
+++ b/src/spaces/regular.rs
@@ -1,4 +1,9 @@
-use super::*;
+use {Dimension, Space, Span, Surjection};
+use dimensions::{Continuous, Partitioned};
+use rand::ThreadRng;
+use std::iter::FromIterator;
+use std::slice::Iter as SliceIter;
+use std::ops::{Add, Index};
 
 /// N-dimensional homogeneous space.
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -37,7 +42,7 @@ impl<D: Dimension> RegularSpace<D> {
     }
 }
 
-impl RegularSpace<dimensions::Continuous> {
+impl RegularSpace<Continuous> {
     pub fn partitioned(self, density: usize) -> RegularSpace<Partitioned> {
         self.into_iter()
             .map(|d| Partitioned::from_continuous(d, density))
@@ -45,7 +50,7 @@ impl RegularSpace<dimensions::Continuous> {
     }
 }
 
-impl RegularSpace<dimensions::Partitioned> {
+impl RegularSpace<Partitioned> {
     pub fn centres(&self) -> Vec<Vec<f64>> {
         self.dimensions
             .iter()
@@ -67,6 +72,15 @@ impl<D: Dimension> Space for RegularSpace<D> {
 
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<D, X> Surjection<Vec<X>, Vec<D::Value>> for RegularSpace<D>
+where
+    D: Dimension + Surjection<X, <D as Dimension>::Value>,
+{
+    fn map(&self, val: Vec<X>) -> Vec<D::Value> {
+        self.dimensions.iter().zip(val.into_iter()).map(|(d, v)| d.map(v)).collect()
     }
 }
 

--- a/src/spaces/unitary.rs
+++ b/src/spaces/unitary.rs
@@ -1,4 +1,6 @@
-use super::*;
+use {Dimension, Space, Span, Surjection};
+use dimensions::{Continuous, Partitioned};
+use rand::ThreadRng;
 
 /// 1-dimensional space.
 #[derive(Clone, Copy, Serialize, Deserialize, Debug)]
@@ -10,7 +12,7 @@ impl<D: Dimension> UnitarySpace<D> {
     }
 }
 
-impl UnitarySpace<dimensions::Continuous> {
+impl UnitarySpace<Continuous> {
     pub fn partitioned(self, density: usize) -> UnitarySpace<Partitioned> {
         UnitarySpace(Partitioned::from_continuous(self.0, density))
     }
@@ -29,6 +31,15 @@ impl<D: Dimension> Space for UnitarySpace<D> {
 
     fn span(&self) -> Span {
         self.0.span()
+    }
+}
+
+impl<D, X> Surjection<X, D::Value> for UnitarySpace<D>
+where
+    D: Dimension + Surjection<X, <D as Dimension>::Value>,
+{
+    fn map(&self, val: X) -> D::Value {
+        self.0.map(val)
     }
 }
 

--- a/src/spaces/unitary.rs
+++ b/src/spaces/unitary.rs
@@ -21,16 +21,16 @@ impl UnitarySpace<Continuous> {
 impl<D: Dimension> Space for UnitarySpace<D> {
     type Repr = D::Value;
 
-    fn sample(&self, rng: &mut ThreadRng) -> Self::Repr {
-        self.0.sample(rng)
-    }
-
     fn dim(&self) -> usize {
         1
     }
 
     fn span(&self) -> Span {
         self.0.span()
+    }
+
+    fn sample(&self, rng: &mut ThreadRng) -> Self::Repr {
+        self.0.sample(rng)
     }
 }
 
@@ -46,13 +46,23 @@ where
 
 #[cfg(test)]
 mod tests {
+    use {Space, UnitarySpace, Span, Surjection};
+    use dimensions::{Continuous, Discrete, Partitioned};
     use ndarray::arr1;
     use rand::thread_rng;
-    use spaces::{Space, UnitarySpace, Span};
-    use spaces::dimensions::Discrete;
 
     #[test]
-    fn test_unitary_space() {
+    fn test_dim() {
+        assert_eq!(UnitarySpace::new(Discrete::new(2)).dim(), 1);
+    }
+
+    #[test]
+    fn test_span() {
+        assert_eq!(UnitarySpace::new(Discrete::new(2)).span(), Span::Finite(2));
+    }
+
+    #[test]
+    fn test_sample() {
         let us = UnitarySpace::new(Discrete::new(2));
         let mut rng = thread_rng();
 
@@ -65,7 +75,22 @@ mod tests {
         }
 
         assert!((counts/5000.0).all_close(&arr1(&vec![0.5; 2]), 1e-1));
-        assert_eq!(us.dim(), 1);
-        assert_eq!(us.span(), Span::Finite(2));
+    }
+
+    #[test]
+    fn test_partitioned() {
+        let us = UnitarySpace::new(Continuous::new(0.0, 5.0));
+        let us = us.partitioned(5);
+
+        assert_eq!(us.0, Partitioned::new(0.0, 5.0, 5));
+    }
+
+    #[test]
+    fn test_surjection() {
+        let us = UnitarySpace::new(Continuous::new(0.0, 5.0));
+
+        assert_eq!(us.map(6.0), 5.0);
+        assert_eq!(us.map(2.5), 2.5);
+        assert_eq!(us.map(-1.0), 0.0);
     }
 }


### PR DESCRIPTION
A surjection is a many-to-one mapping from one set/space _onto_ another where each input has exactly one corresponding value. Specifically, for every element y in the codomain Y of f, there is at least one element x in the domain X of f such that f(x) = y.

This trait thus defines compatible mappings from one value onto another contained within this domain. In the majority of cases this amounts to clipping the value to lie within the given limits.

Before these methods were implemented via the `convert` method in the `Dimension` trait. However, a surjection (which the convert method was, basically) is not restricted to these types and now we may implement it uniformly across all the `Space` types as well.