### PR TITLE
Rename Discrete -> Ordinal

### DIFF
--- a/src/core/card.rs
+++ b/src/core/card.rs
@@ -8,10 +8,10 @@ use std::ops::Mul;
 /// ```
 /// use spaces::{Space, Card};
 /// use spaces::product::PairSpace;
-/// use spaces::discrete::Discrete;
+/// use spaces::discrete::Ordinal;
 ///
-/// let d1 = Discrete::new(5);
-/// let d2 = Discrete::new(10);
+/// let d1 = Ordinal::new(5);
+/// let d2 = Ordinal::new(10);
 /// let space = PairSpace::new(d1, d2);
 ///
 /// assert_eq!(space.card(), Card::Finite(50));

--- a/src/discrete/mod.rs
+++ b/src/discrete/mod.rs
@@ -1,7 +1,7 @@
 //! Discrete spaces module.
 
 import_all!(binary);
-import_all!(discrete);
+import_all!(ordinal);
 import_all!(naturals);
 import_all!(integers);
 import_all!(interval);

--- a/src/discrete/ordinal.rs
+++ b/src/discrete/ordinal.rs
@@ -9,23 +9,23 @@ use std::{
 
 /// Type representing a finite, ordinal set of values.
 #[derive(Clone, Copy, Serialize)]
-pub struct Discrete {
+pub struct Ordinal {
     size: usize,
 
     #[serde(skip_serializing)]
     range: RngRange<usize>,
 }
 
-impl Discrete {
-    pub fn new(size: usize) -> Discrete {
-        Discrete {
+impl Ordinal {
+    pub fn new(size: usize) -> Ordinal {
+        Ordinal {
             size: size,
             range: RngRange::new(0, size),
         }
     }
 }
 
-impl Space for Discrete {
+impl Space for Ordinal {
     type Value = usize;
 
     fn dim(&self) -> usize { 1 }
@@ -37,7 +37,7 @@ impl Space for Discrete {
     }
 }
 
-impl BoundedSpace for Discrete {
+impl BoundedSpace for Ordinal {
     type BoundValue = usize;
 
     fn inf(&self) -> Option<usize> { Some(0) }
@@ -47,15 +47,15 @@ impl BoundedSpace for Discrete {
     fn contains(&self, val: Self::Value) -> bool { val < self.size }
 }
 
-impl FiniteSpace for Discrete {
+impl FiniteSpace for Ordinal {
     fn range(&self) -> Range<Self::Value> { 0..self.size }
 }
 
-impl Surjection<usize, usize> for Discrete {
+impl Surjection<usize, usize> for Ordinal {
     fn map(&self, val: usize) -> usize { val as usize }
 }
 
-impl<'de> Deserialize<'de> for Discrete {
+impl<'de> Deserialize<'de> for Ordinal {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: Deserializer<'de> {
         enum Field {
@@ -88,24 +88,24 @@ impl<'de> Deserialize<'de> for Discrete {
             }
         }
 
-        struct DiscreteVisitor;
+        struct OrdinalVisitor;
 
-        impl<'de> Visitor<'de> for DiscreteVisitor {
-            type Value = Discrete;
+        impl<'de> Visitor<'de> for OrdinalVisitor {
+            type Value = Ordinal;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct Discrete")
+                formatter.write_str("struct Ordinal")
             }
 
-            fn visit_seq<V>(self, mut seq: V) -> Result<Discrete, V::Error>
+            fn visit_seq<V>(self, mut seq: V) -> Result<Ordinal, V::Error>
             where V: de::SeqAccess<'de> {
                 let size = seq.next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
 
-                Ok(Discrete::new(size))
+                Ok(Ordinal::new(size))
             }
 
-            fn visit_map<V>(self, mut map: V) -> Result<Discrete, V::Error>
+            fn visit_map<V>(self, mut map: V) -> Result<Ordinal, V::Error>
             where V: de::MapAccess<'de> {
                 let mut size = None;
 
@@ -121,29 +121,29 @@ impl<'de> Deserialize<'de> for Discrete {
                     }
                 }
 
-                Ok(Discrete::new(size.ok_or_else(|| {
+                Ok(Ordinal::new(size.ok_or_else(|| {
                     de::Error::missing_field("size")
                 })?))
             }
         }
 
-        deserializer.deserialize_struct("Discrete", FIELDS, DiscreteVisitor)
+        deserializer.deserialize_struct("Ordinal", FIELDS, OrdinalVisitor)
     }
 }
 
-impl cmp::PartialEq for Discrete {
-    fn eq(&self, other: &Discrete) -> bool { self.size.eq(&other.size) }
+impl cmp::PartialEq for Ordinal {
+    fn eq(&self, other: &Ordinal) -> bool { self.size.eq(&other.size) }
 }
 
-impl fmt::Debug for Discrete {
+impl fmt::Debug for Ordinal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Discrete")
+        f.debug_struct("Ordinal")
             .field("size", &self.size)
             .finish()
     }
 }
 
-impl fmt::Display for Discrete {
+impl fmt::Display for Ordinal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[0..{}]", self.size-1)
     }
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn test_card() {
         fn check(size: usize) {
-            let d = Discrete::new(size);
+            let d = Ordinal::new(size);
 
             assert_eq!(d.card(), Card::Finite(size));
         }
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn test_sampling() {
         fn check(size: usize) {
-            let d = Discrete::new(size);
+            let d = Ordinal::new(size);
             let mut rng = thread_rng();
 
             for _ in 0..100 {
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn test_bounds() {
         fn check(size: usize) {
-            let d = Discrete::new(size);
+            let d = Ordinal::new(size);
 
             assert_eq!(d.inf().unwrap(), 0);
             assert_eq!(d.sup().unwrap(), size - 1);
@@ -208,14 +208,14 @@ mod tests {
 
     #[test]
     fn test_range() {
-        assert_eq!(Discrete::new(1).range(), 0..1);
-        assert_eq!(Discrete::new(5).range(), 0..5);
-        assert_eq!(Discrete::new(10).range(), 0..10);
+        assert_eq!(Ordinal::new(1).range(), 0..1);
+        assert_eq!(Ordinal::new(5).range(), 0..5);
+        assert_eq!(Ordinal::new(10).range(), 0..10);
     }
 
     #[test]
     fn test_surjection() {
-        let d = Discrete::new(10);
+        let d = Ordinal::new(10);
 
         assert_eq!(d.map(0), 0);
         assert_eq!(d.map(1), 1);
@@ -232,13 +232,13 @@ mod tests {
     #[test]
     fn test_serialisation() {
         fn check(size: usize) {
-            let d = Discrete::new(size);
+            let d = Ordinal::new(size);
 
             assert_tokens(
                 &d,
                 &[
                     Token::Struct {
-                        name: "Discrete",
+                        name: "Ordinal",
                         len: 1,
                     },
                     Token::Str("size"),

--- a/src/product/named.rs
+++ b/src/product/named.rs
@@ -145,7 +145,7 @@ mod tests {
 
     use continuous::Interval;
     use core::{Space, Card, Surjection};
-    use discrete::Discrete;
+    use discrete::Ordinal;
     use product::NamedSpace;
     use rand::thread_rng;
     use self::ndarray::arr1;
@@ -155,7 +155,7 @@ mod tests {
     #[test]
     fn test_dim() {
         assert_eq!(
-            NamedSpace::new(vec![("D1", Discrete::new(2)), ("D2", Discrete::new(2))]).dim(),
+            NamedSpace::new(vec![("D1", Ordinal::new(2)), ("D2", Ordinal::new(2))]).dim(),
             2
         );
     }
@@ -163,14 +163,14 @@ mod tests {
     #[test]
     fn test_card() {
         assert_eq!(
-            NamedSpace::new(vec![("D1", Discrete::new(2)), ("D2", Discrete::new(2))]).card(),
+            NamedSpace::new(vec![("D1", Ordinal::new(2)), ("D2", Ordinal::new(2))]).card(),
             Card::Finite(4)
         );
     }
 
     #[test]
     fn test_sampling() {
-        let space = NamedSpace::new(vec![("D1", Discrete::new(2)), ("D2", Discrete::new(2))]);
+        let space = NamedSpace::new(vec![("D1", Ordinal::new(2)), ("D2", Ordinal::new(2))]);
 
         let mut rng = thread_rng();
 

--- a/src/product/pair.rs
+++ b/src/product/pair.rs
@@ -58,27 +58,27 @@ mod tests {
 
     use continuous::Interval;
     use core::{Space, Card, Surjection};
-    use discrete::{Discrete, Partition};
+    use discrete::{Ordinal, Partition};
     use product::PairSpace;
     use rand::thread_rng;
     use self::ndarray::arr1;
 
     #[test]
     fn test_dim() {
-        assert_eq!(PairSpace::new(Discrete::new(2), Discrete::new(2)).dim(), 2);
+        assert_eq!(PairSpace::new(Ordinal::new(2), Ordinal::new(2)).dim(), 2);
     }
 
     #[test]
     fn test_card() {
         assert_eq!(
-            PairSpace::new(Discrete::new(2), Discrete::new(2)).card(),
+            PairSpace::new(Ordinal::new(2), Ordinal::new(2)).card(),
             Card::Finite(4)
         );
     }
 
     #[test]
     fn test_sample() {
-        let ps = PairSpace::new(Discrete::new(2), Discrete::new(2));
+        let ps = PairSpace::new(Ordinal::new(2), Ordinal::new(2));
 
         let mut rng = thread_rng();
 

--- a/src/product/regular.rs
+++ b/src/product/regular.rs
@@ -133,7 +133,7 @@ mod tests {
 
     use continuous::Interval;
     use core::{Space, Card, Surjection};
-    use discrete::Discrete;
+    use discrete::Ordinal;
     use product::RegularSpace;
     use rand::thread_rng;
     use self::ndarray::arr1;
@@ -141,20 +141,20 @@ mod tests {
 
     #[test]
     fn test_dim() {
-        assert_eq!(RegularSpace::new(vec![Discrete::new(2); 2]).dim(), 2);
+        assert_eq!(RegularSpace::new(vec![Ordinal::new(2); 2]).dim(), 2);
     }
 
     #[test]
     fn test_card() {
         assert_eq!(
-            RegularSpace::new(vec![Discrete::new(2); 2]).card(),
+            RegularSpace::new(vec![Ordinal::new(2); 2]).card(),
             Card::Finite(4)
         );
     }
 
     #[test]
     fn test_sampling() {
-        let space = RegularSpace::new(vec![Discrete::new(2); 2]);
+        let space = RegularSpace::new(vec![Ordinal::new(2); 2]);
 
         let mut rng = thread_rng();
 
@@ -202,14 +202,14 @@ mod tests {
 
     #[test]
     fn test_add_op() {
-        let mut sa = RegularSpace::new(vec![Discrete::new(2); 2]);
-        let mut sb = RegularSpace::empty() + Discrete::new(2) + Discrete::new(2);
+        let mut sa = RegularSpace::new(vec![Ordinal::new(2); 2]);
+        let mut sb = RegularSpace::empty() + Ordinal::new(2) + Ordinal::new(2);
 
         assert_eq!(sa.dim(), sb.dim());
         assert_eq!(sa.card(), sb.card());
 
-        sa = sa + Discrete::new(3);
-        sb = sb + Discrete::new(3);
+        sa = sa + Ordinal::new(3);
+        sb = sb + Ordinal::new(3);
 
         assert_eq!(sa.dim(), 3);
         assert_eq!(sa.dim(), sb.dim());


### PR DESCRIPTION
The name discrete is not very specific. Indeed we now have lots of different discrete `Space` types so we need a more appropriate name. Ordinal variables are categorical with a implied ordering over it's possible values. This is exactly what the original implementation was meant to represent.

See #15 