### PR TITLE
Deprecate Space::sample

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ travis-ci = { repository = "tspooner/spaces", branch = "master" }
 coveralls = { repository = "tspooner/spaces", branch = "master", service = "github" }
 
 [dependencies]
-rand = "0.6"
 ndarray = { version = "0.12", features = ["serde-1"] }
 
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "tspooner/spaces", branch = "master" }
 coveralls = { repository = "tspooner/spaces", branch = "master", service = "github" }
 
 [dependencies]
-rand = "0.5"
+rand = "0.6"
 ndarray = { version = "0.12", features = ["serde-1"] }
 
 serde = "1.0"

--- a/src/continuous/interval.rs
+++ b/src/continuous/interval.rs
@@ -1,4 +1,4 @@
-use rand::{Rng, distributions::{Distribution, Range as RngRange}};
+use rand::{Rng, distributions::{Distribution, Uniform}};
 use serde::{Deserialize, Deserializer, de::{self, Visitor}};
 use std::{cmp, fmt};
 use {BoundedSpace, Space, Card, Surjection};
@@ -10,14 +10,14 @@ pub struct Interval {
     pub(crate) ub: Option<f64>,
 
     #[serde(skip_serializing)]
-    pub(crate) range: Option<RngRange<f64>>,
+    pub(crate) range: Option<Uniform<f64>>,
 }
 
 impl Interval {
     fn new(lb: Option<f64>, ub: Option<f64>) -> Interval {
         Interval {
             range: match (lb, ub) {
-                (Some(lb), Some(ub)) => Some(RngRange::new(lb, ub)),
+                (Some(lb), Some(ub)) => Some(Uniform::new_inclusive(lb, ub)),
                 _ => None
             },
 
@@ -30,7 +30,7 @@ impl Interval {
             lb: Some(lb),
             ub: Some(ub),
 
-            range: Some(RngRange::new(lb, ub)),
+            range: Some(Uniform::new_inclusive(lb, ub)),
         }
     }
 

--- a/src/continuous/nonnegative_reals.rs
+++ b/src/continuous/nonnegative_reals.rs
@@ -1,5 +1,4 @@
 use core::{BoundedSpace, Space, Card, Surjection};
-use rand::Rng;
 
 /// Type representing the set of non-negative real numbers, R(≥0).
 #[derive(Clone, Copy, Serialize)]
@@ -11,10 +10,6 @@ impl Space for NonNegativeReals {
     fn dim(&self) -> usize { 1 }
 
     fn card(&self) -> Card { Card::Infinite }
-
-    fn sample<R: Rng + ?Sized>(&self, _: &mut R) -> f64 {
-        unimplemented!()
-    }
 }
 
 impl BoundedSpace for NonNegativeReals {

--- a/src/continuous/positive_reals.rs
+++ b/src/continuous/positive_reals.rs
@@ -1,5 +1,4 @@
 use core::{BoundedSpace, Space, Card, Surjection};
-use rand::Rng;
 
 /// Type representing the set of strictly positive real numbers, R(>0).
 #[derive(Clone, Copy, Serialize)]
@@ -11,10 +10,6 @@ impl Space for PositiveReals {
     fn dim(&self) -> usize { 1 }
 
     fn card(&self) -> Card { Card::Infinite }
-
-    fn sample<R: Rng + ?Sized>(&self, _: &mut R) -> f64 {
-        unimplemented!()
-    }
 }
 
 impl BoundedSpace for PositiveReals {

--- a/src/continuous/reals.rs
+++ b/src/continuous/reals.rs
@@ -1,6 +1,5 @@
 use continuous::Interval;
 use core::{Space, Card, Surjection};
-use rand::Rng;
 
 /// Type representing the set of all real numbers.
 #[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
@@ -20,8 +19,6 @@ impl Space for Reals {
     fn dim(&self) -> usize { 1 }
 
     fn card(&self) -> Card { Card::Infinite }
-
-    fn sample<R: Rng + ?Sized>(&self, _: &mut R) -> f64 { unimplemented!() }
 }
 
 impl Surjection<f64, f64> for Reals {
@@ -34,7 +31,6 @@ mod tests {
 
     use self::serde_test::{assert_tokens, Token};
     use super::*;
-    use rand::{thread_rng, Rng};
 
     #[test]
     fn test_bounded() {
@@ -53,21 +49,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_sampling() {
-        let d = Reals;
-        let mut rng = thread_rng();
-
-        let _ = d.sample(&mut rng);
-    }
-
-    #[test]
     fn test_surjection() {
         let d = Reals;
-        let mut rng = thread_rng();
 
-        for _ in 0..10 {
-            let v = rng.gen::<f64>();
+        for i in -10..10 {
+            let v = i as f64;
 
             assert_eq!(d.map(v), v);
         }

--- a/src/core/space.rs
+++ b/src/core/space.rs
@@ -1,8 +1,6 @@
 use core::Card;
-use rand::Rng;
 use std::fmt::Debug;
 use std::ops::Range;
-
 
 /// Trait for defining geometric spaces.
 pub trait Space {
@@ -14,9 +12,6 @@ pub trait Space {
 
     /// Return the number of elements in the set composing the space.
     fn card(&self) -> Card;
-
-    /// Generate a random sample from the space.
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::Value;
 }
 
 impl<D: Space> Space for Box<D> {
@@ -25,10 +20,6 @@ impl<D: Space> Space for Box<D> {
     fn dim(&self) -> usize { (**self).dim() }
 
     fn card(&self) -> Card { (**self).card() }
-
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::Value {
-        (**self).sample(rng)
-    }
 }
 
 impl<'a, D: Space> Space for &'a D {
@@ -37,10 +28,6 @@ impl<'a, D: Space> Space for &'a D {
     fn dim(&self) -> usize { (**self).dim() }
 
     fn card(&self) -> Card { (**self).card() }
-
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::Value {
-        (**self).sample(rng)
-    }
 }
 
 /// Trait for defining spaces bounded to lie on an interval I.

--- a/src/discrete/binary.rs
+++ b/src/discrete/binary.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use std::ops::Range;
 use {BoundedSpace, FiniteSpace, Space, Card, Surjection};
 
@@ -16,8 +15,6 @@ impl Space for Binary {
     fn dim(&self) -> usize { 1 }
 
     fn card(&self) -> Card { Card::Finite(2) }
-
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> bool { rng.gen() }
 }
 
 impl BoundedSpace for Binary {
@@ -48,26 +45,12 @@ mod tests {
 
     use self::serde_test::{assert_tokens, Token};
     use super::*;
-    use rand::thread_rng;
 
     #[test]
     fn test_card() {
         let d = Binary::new();
 
         assert_eq!(d.card(), Card::Finite(2));
-    }
-
-    #[test]
-    fn test_sampling() {
-        let d = Binary::new();
-        let mut rng = thread_rng();
-
-        for _ in 0..100 {
-            let s = d.sample(&mut rng);
-
-            assert!(s == false || s == true);
-            assert!(d.contains(s));
-        }
     }
 
     #[test]

--- a/src/discrete/discrete.rs
+++ b/src/discrete/discrete.rs
@@ -1,4 +1,4 @@
-use rand::{Rng, distributions::{Distribution, Range as RngRange}};
+use rand::{Rng, distributions::{Distribution, Uniform}};
 use serde::{Deserialize, Deserializer, de::{self, Visitor}};
 use std::{cmp, fmt, ops::Range};
 use {BoundedSpace, FiniteSpace, Space, Card, Surjection};
@@ -9,14 +9,14 @@ pub struct Discrete {
     size: usize,
 
     #[serde(skip_serializing)]
-    range: RngRange<usize>,
+    range: Uniform<usize>,
 }
 
 impl Discrete {
     pub fn new(size: usize) -> Discrete {
         Discrete {
             size: size,
-            range: RngRange::new(0, size),
+            range: Uniform::new_inclusive(0, size),
         }
     }
 }

--- a/src/discrete/discrete.rs
+++ b/src/discrete/discrete.rs
@@ -1,22 +1,17 @@
-use rand::{Rng, distributions::{Distribution, Uniform}};
+use core::{BoundedSpace, FiniteSpace, Space, Card, Surjection};
 use serde::{Deserialize, Deserializer, de::{self, Visitor}};
 use std::{cmp, fmt, ops::Range};
-use {BoundedSpace, FiniteSpace, Space, Card, Surjection};
 
 /// Type representing a finite, ordinal set of values.
 #[derive(Clone, Copy, Serialize)]
 pub struct Discrete {
     size: usize,
-
-    #[serde(skip_serializing)]
-    range: Uniform<usize>,
 }
 
 impl Discrete {
     pub fn new(size: usize) -> Discrete {
         Discrete {
             size: size,
-            range: Uniform::new_inclusive(0, size),
         }
     }
 }
@@ -27,10 +22,6 @@ impl Space for Discrete {
     fn dim(&self) -> usize { 1 }
 
     fn card(&self) -> Card { Card::Finite(self.size) }
-
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        self.range.sample(rng)
-    }
 }
 
 impl BoundedSpace for Discrete {
@@ -145,7 +136,6 @@ mod tests {
 
     use self::serde_test::{assert_tokens, Token};
     use super::*;
-    use rand::thread_rng;
 
     #[test]
     fn test_card() {
@@ -153,24 +143,6 @@ mod tests {
             let d = Discrete::new(size);
 
             assert_eq!(d.card(), Card::Finite(size));
-        }
-
-        check(5);
-        check(10);
-        check(100);
-    }
-
-    #[test]
-    fn test_sampling() {
-        fn check(size: usize) {
-            let d = Discrete::new(size);
-            let mut rng = thread_rng();
-
-            for _ in 0..100 {
-                let s = d.sample(&mut rng);
-
-                assert!(s < size);
-            }
         }
 
         check(5);

--- a/src/discrete/integers.rs
+++ b/src/discrete/integers.rs
@@ -1,5 +1,5 @@
-use rand::Rng;
-use {BoundedSpace, Space, Card, discrete::Naturals};
+use core::{BoundedSpace, Space, Card};
+use discrete::Naturals;
 
 /// Type representing the set of integers, Z.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -11,8 +11,6 @@ impl Space for Integers {
     fn dim(&self) -> usize { 1 }
 
     fn card(&self) -> Card { Card::Infinite }
-
-    fn sample<R: Rng + ?Sized>(&self, _: &mut R) -> i64 { unimplemented!() }
 }
 
 impl BoundedSpace for Integers {
@@ -35,8 +33,6 @@ impl Space for NonZeroIntegers {
     fn dim(&self) -> usize { 1 }
 
     fn card(&self) -> Card { Card::Infinite }
-
-    fn sample<R: Rng + ?Sized>(&self, _: &mut R) -> i64 { unimplemented!() }
 }
 
 impl BoundedSpace for NonZeroIntegers {
@@ -59,8 +55,6 @@ impl Space for NonNegativeIntegers {
     fn dim(&self) -> usize { 1 }
 
     fn card(&self) -> Card { Card::Infinite }
-
-    fn sample<R: Rng + ?Sized>(&self, _: &mut R) -> u64 { unimplemented!() }
 }
 
 impl BoundedSpace for NonNegativeIntegers {

--- a/src/discrete/naturals.rs
+++ b/src/discrete/naturals.rs
@@ -1,5 +1,4 @@
-use rand::Rng;
-use {BoundedSpace, Space, Card};
+use core::{BoundedSpace, Space, Card};
 
 /// Type representing the set of natural numbers, N.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -11,8 +10,6 @@ impl Space for Naturals {
     fn dim(&self) -> usize { 1 }
 
     fn card(&self) -> Card { Card::Infinite }
-
-    fn sample<R: Rng + ?Sized>(&self, _: &mut R) -> u64 { unimplemented!() }
 }
 
 impl BoundedSpace for Naturals {

--- a/src/discrete/partition.rs
+++ b/src/discrete/partition.rs
@@ -1,6 +1,6 @@
 use continuous::Interval;
 use core::{BoundedSpace, FiniteSpace, Space, Card, Surjection};
-use rand::{Rng, distributions::{Distribution, Range as RngRange}};
+use rand::{Rng, distributions::{Distribution, Uniform}};
 use serde::{Deserialize, Deserializer, de::{self, Visitor}};
 use std::{cmp, fmt, ops::Range};
 
@@ -12,7 +12,7 @@ pub struct Partition {
     density: usize,
 
     #[serde(skip_serializing)]
-    range: RngRange<f64>,
+    range: Uniform<f64>,
 }
 
 impl Partition {
@@ -22,7 +22,7 @@ impl Partition {
             ub: ub,
             density: density,
 
-            range: RngRange::new(lb, ub),
+            range: Uniform::new_inclusive(lb, ub),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 //! be used to define state/action spaces, for example. Mappings between
 //! different spaces may also be defined using traits such as `Surjection` to
 //! streamline many common preprocessing and type conversion tasks.
-extern crate rand;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/src/product/pair.rs
+++ b/src/product/pair.rs
@@ -1,7 +1,6 @@
 use continuous::Interval;
 use core::{Space, Card, Surjection};
 use discrete::Partition;
-use rand::Rng;
 
 /// 2-dimensional homogeneous space.
 #[derive(Clone, Copy, Serialize, Deserialize, Debug)]
@@ -17,8 +16,8 @@ impl<D1: Space, D2: Space> PairSpace<D1, D2> {
 impl PairSpace<Interval, Interval> {
     pub fn partitioned(self, density: usize) -> PairSpace<Partition, Partition> {
         PairSpace(
-            Partition::from_continuous(self.0, density),
-            Partition::from_continuous(self.1, density),
+            Partition::from_interval(self.0, density),
+            Partition::from_interval(self.1, density),
         )
     }
 }
@@ -29,10 +28,6 @@ impl<D1: Space, D2: Space> Space for PairSpace<D1, D2> {
     fn dim(&self) -> usize { 2 }
 
     fn card(&self) -> Card { self.0.card() * self.1.card() }
-
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> (D1::Value, D2::Value) {
-        (self.0.sample(rng), self.1.sample(rng))
-    }
 }
 
 impl<D1, X1, D2, X2> Surjection<(X1, X2), (D1::Value, D2::Value)> for PairSpace<D1, D2>
@@ -49,12 +44,10 @@ where
 mod tests {
     extern crate ndarray;
 
-    use continuous::Interval;
     use core::{Space, Card, Surjection};
+    use continuous::Interval;
     use discrete::{Discrete, Partition};
     use product::PairSpace;
-    use rand::thread_rng;
-    use self::ndarray::arr1;
 
     #[test]
     fn test_dim() {
@@ -67,28 +60,6 @@ mod tests {
             PairSpace::new(Discrete::new(2), Discrete::new(2)).card(),
             Card::Finite(4)
         );
-    }
-
-    #[test]
-    fn test_sample() {
-        let ps = PairSpace::new(Discrete::new(2), Discrete::new(2));
-
-        let mut rng = thread_rng();
-
-        let mut c1 = arr1(&vec![0.0; 2]);
-        let mut c2 = arr1(&vec![0.0; 2]);
-        for _ in 0..5000 {
-            let sample = ps.sample(&mut rng);
-
-            c1[sample.0] += 1.0;
-            c2[sample.1] += 1.0;
-
-            assert!(sample.0 == 0 || sample.0 == 1);
-            assert!(sample.1 == 0 || sample.1 == 1);
-        }
-
-        assert!((c1 / 5000.0).all_close(&arr1(&vec![0.5; 2]), 1e-1));
-        assert!((c2 / 5000.0).all_close(&arr1(&vec![0.5; 2]), 1e-1));
     }
 
     #[test]

--- a/src/product/regular.rs
+++ b/src/product/regular.rs
@@ -1,7 +1,6 @@
 use continuous::Interval;
 use core::{Space, Card, Surjection};
 use discrete::Partition;
-use rand::Rng;
 use std::{iter::FromIterator, ops::{Add, Index}, slice::Iter as SliceIter};
 
 /// N-dimensional homogeneous space.
@@ -42,7 +41,7 @@ impl<D: Space> RegularSpace<D> {
 impl RegularSpace<Interval> {
     pub fn partitioned(self, density: usize) -> RegularSpace<Partition> {
         self.into_iter()
-            .map(|d| Partition::from_continuous(d, density))
+            .map(|d| Partition::from_interval(d, density))
             .collect()
     }
 }
@@ -57,10 +56,6 @@ impl<D: Space> Space for RegularSpace<D> {
     fn dim(&self) -> usize { self.dimensions.len() }
 
     fn card(&self) -> Card { self.card }
-
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Vec<D::Value> {
-        self.dimensions.iter().map(|d| d.sample(rng)).collect()
-    }
 }
 
 impl<D, X> Surjection<Vec<X>, Vec<D::Value>> for RegularSpace<D>
@@ -116,8 +111,6 @@ mod tests {
     use core::{Space, Card, Surjection};
     use discrete::Discrete;
     use product::RegularSpace;
-    use rand::thread_rng;
-    use self::ndarray::arr1;
     use std::iter::FromIterator;
 
     #[test]
@@ -131,28 +124,6 @@ mod tests {
             RegularSpace::new(vec![Discrete::new(2); 2]).card(),
             Card::Finite(4)
         );
-    }
-
-    #[test]
-    fn test_sampling() {
-        let space = RegularSpace::new(vec![Discrete::new(2); 2]);
-
-        let mut rng = thread_rng();
-
-        let mut c1 = arr1(&vec![0.0; 2]);
-        let mut c2 = arr1(&vec![0.0; 2]);
-        for _ in 0..5000 {
-            let sample = space.sample(&mut rng);
-
-            c1[sample[0]] += 1.0;
-            c2[sample[1]] += 1.0;
-
-            assert!(sample[0] == 0 || sample[0] == 1);
-            assert!(sample[1] == 0 || sample[1] == 1);
-        }
-
-        assert!((c1 / 5000.0).all_close(&arr1(&vec![0.5; 2]), 1e-1));
-        assert!((c2 / 5000.0).all_close(&arr1(&vec![0.5; 2]), 1e-1));
     }
 
     #[test]


### PR DESCRIPTION
This method has been a bit of a nuisance as other crates have evolved. Further, it doesn't make sense to have this without any notion of what the probability distribution is over the space: it is not known by the user whether they're doing uniform sampling or some weighted variant.

This PR will require a major version push as there may be a lot of code that is broken.